### PR TITLE
Update sdk

### DIFF
--- a/io.gitlab.coolreader_ng.crqt-ng.yml
+++ b/io.gitlab.coolreader_ng.crqt-ng.yml
@@ -1,6 +1,6 @@
 app-id: io.gitlab.coolreader_ng.crqt-ng
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 command: crqt
 rename-desktop-file: crqt.desktop

--- a/io.gitlab.coolreader_ng.crqt-ng.yml
+++ b/io.gitlab.coolreader_ng.crqt-ng.yml
@@ -67,7 +67,6 @@ modules:
       - -DUSE_CHM=ON
       - -DUSE_ANTIWORD=ON
       - -DUSE_SHASUM=OFF
-      - -DUSE_CMARK=OFF
       - -DUSE_CMARK_GFM=ON
       - -DWITH_LIBPNG=ON
       - -DWITH_LIBJPEG=ON


### PR DESCRIPTION
* Bump org.kde.Sdk to 5.15-23.08
* Stale cmake option removed for crengine-ng