### PR TITLE
Explicit use of libwebp

### DIFF
--- a/io.gitlab.coolreader_ng.crqt-ng.yml
+++ b/io.gitlab.coolreader_ng.crqt-ng.yml
@@ -71,6 +71,7 @@ modules:
       - -DUSE_MD4C=ON
       - -DWITH_LIBPNG=ON
       - -DWITH_LIBJPEG=ON
+      - -DWITH_LIBWEBP=ON
       - -DWITH_FREETYPE=ON
       - -DWITH_HARFBUZZ=ON
       - -DWITH_LIBUNIBREAK=ON


### PR DESCRIPTION
Explicit use of libwebp (since crengine-ng-0.9.13)